### PR TITLE
Add comments to posts

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -43,6 +43,7 @@ CREATE TABLE IF NOT EXISTS `posts` (
   `author` INT,
   `category` INT,
   `published` TINYINT (1) DEFAULT 1,
+  `commentsAllowed` TINYINT(1) DEFAULT 1,
   `createdAt` DATETIME DEFAULT CURRENT_TIMESTAMP,
   `updatedAt` DATETIME DEFAULT NULL,
   PRIMARY KEY (`id`),

--- a/db.sql
+++ b/db.sql
@@ -60,7 +60,6 @@ CREATE TABLE IF NOT EXISTS `comments` (
   `author` INT,
   `approved` TINYINT (1) DEFAULT 0,
   `createdAt` DATETIME DEFAULT CURRENT_TIMESTAMP,
-  `updatedAt` DATETIME DEFAULT NULL,
   PRIMARY KEY (`id`),
   CONSTRAINT `fk_comments_postId` FOREIGN KEY (`postId`) REFERENCES `posts` (`id`) ON UPDATE CASCADE ON DELETE CASCADE,
   CONSTRAINT `fk_comments_author` FOREIGN KEY (`author`) REFERENCES `users` (`id`) ON UPDATE CASCADE ON DELETE SET NULL,

--- a/public/index.php
+++ b/public/index.php
@@ -56,6 +56,15 @@ $routes = [
     ],
     "/posts/(\d+)/comments" => [
         "GET" => fn (int $postId) => (new CommentController())->redirectToPostPage($postId),
+        "POST" => fn (int $postId) => (new CommentController())->createComment($postId),
+    ],
+    "/posts/(\d+)/comments/(\d+)" => [
+        "GET" => fn (int $postId) => (new CommentController())->redirectToPostPage($postId),
+        "DELETE" => fn (int $postId, int $commentId) => (new CommentController())->deleteComment($commentId),
+    ],
+    "/posts/(\d+)/comments/(\d+)/delete" => [
+        "GET" => fn (int $postId) => (new CommentController())->redirectToPostPage($postId),
+        "POST" => fn (int $postId, int $commentId) => (new CommentController())->deleteComment($commentId),
     ],
     "/posts/(\d+)/comments/create" => [
         "GET" => fn (int $postId) => (new CommentController())->redirectToPostPage($postId),

--- a/public/index.php
+++ b/public/index.php
@@ -54,7 +54,10 @@ $routes = [
     "/posts/(\d+)" => [
         "GET" => fn (int $id) => (new PostController())->showOne($id),
     ],
-    "/posts/(\d+)/createComment" => [
+    "/posts/(\d+)/comments" => [
+        "GET" => fn (int $postId) => (new CommentController())->redirectToPostPage($postId),
+    ],
+    "/posts/(\d+)/comments/create" => [
         "GET" => fn (int $postId) => (new CommentController())->redirectToPostPage($postId),
         "POST" => fn (int $postId) => (new CommentController())->createComment($postId),
     ],
@@ -114,8 +117,14 @@ $routes = [
     ],
     "/admin/comments/(\d+)" => [
         "GET" => fn (int $id) => (new CommentManagementController())->showReviewPage($id),
-        "POST" => fn (int $id) => (new CommentManagementController())->editComment($id),
-        "DELETE" => fn (int $id) => (new CommentManagementController())->deleteComment($id),
+    ],
+    "/admin/comments/(\d+)/approve" => [
+        "GET" => fn (int $id) => (new CommentManagementController())->showReviewPage($id),
+        "POST" => fn (int $id) => (new CommentManagementController())->approveComment($id),
+    ],
+    "/admin/comments/(\d+)/reject" => [
+        "GET" => fn (int $id) => (new CommentManagementController())->showReviewPage($id),
+        "POST" => fn (int $id) => (new CommentManagementController())->rejectComment($id),
     ],
     "/admin/users" => [
         "GET" => fn () => (new UserManagementController())->show(),

--- a/public/index.php
+++ b/public/index.php
@@ -29,9 +29,11 @@ use App\Core\Router;
 use App\Core\ErrorLogger;
 use App\Controller\HomepageController;
 use App\Controller\PostController;
+use App\Controller\CommentController;
 use App\Controller\UserController;
 use App\Controller\Admin\DashboardController;
 use App\Controller\Admin\PostManagementController;
+use App\Controller\Admin\CommentManagementController;
 use App\Controller\Admin\UserManagementController;
 use App\Controller\ErrorController;
 use App\Core\Exceptions\Client\ClientException;
@@ -51,6 +53,10 @@ $routes = [
     ],
     "/posts/(\d+)" => [
         "GET" => fn (int $id) => (new PostController())->showOne($id),
+    ],
+    "/posts/(\d+)/createComment" => [
+        "GET" => fn (int $postId) => (new CommentController())->redirectToPostPage($postId),
+        "POST" => fn (int $postId) => (new CommentController())->createComment($postId),
     ],
     "/user" => [
         "GET" => fn () => (new UserController())->showAccountPage(),
@@ -102,6 +108,14 @@ $routes = [
     "/admin/posts/create" => [
         "GET" => fn () => (new PostManagementController())->showEditPage(),
         "POST" => fn () => (new PostManagementController())->createPost(),
+    ],
+    "/admin/comments" => [
+        "GET" => fn () => (new CommentManagementController())->show(),
+    ],
+    "/admin/comments/(\d+)" => [
+        "GET" => fn (int $id) => (new CommentManagementController())->showReviewPage($id),
+        "POST" => fn (int $id) => (new CommentManagementController())->editComment($id),
+        "DELETE" => fn (int $id) => (new CommentManagementController())->deleteComment($id),
     ],
     "/admin/users" => [
         "GET" => fn () => (new UserManagementController())->show(),

--- a/public/js/front/comments.js
+++ b/public/js/front/comments.js
@@ -1,0 +1,66 @@
+/**
+ * Comment deletion.
+ */
+
+/** @type {HTMLUListElement} */
+const commentList = document.getElementById("commentList");
+
+if (commentList) {
+  /** @type {NodeListOf<HTMLLIElement>} */
+  const comments = commentList.querySelectorAll(".js-comment");
+
+  const deleteFormResultMessageCss = {
+    success: ["fw-bold", "text-success"],
+    error: "invalid-feedback",
+  };
+
+  comments.forEach((comment) => {
+    const commentId = comment.dataset.commentId;
+
+    console.log({ commentId });
+
+    /** @type {HTMLFormElement} */
+    const deleteForm = comment.querySelector(".js-delete-form");
+
+    if (!deleteForm) return;
+
+    const deleteButton = deleteForm.querySelector("button");
+
+    /** @type {HTMLDivElement} */
+    const deleteFormResult = comment.querySelector(".js-delete-form-result");
+
+    deleteForm.addEventListener("submit", async (e) => {
+      e.preventDefault();
+
+      deleteFormResult.classList.add("d-none");
+
+      try {
+        deleteButton.textContent = "Suppression...";
+        deleteButton.setAttribute("disabled", true);
+
+        const response = await fetch("/posts/0/comments/" + commentId, {
+          method: "DELETE",
+          headers: {
+            Accept: "application/json",
+          },
+        });
+
+        const message =
+          (await response.json())?.message || "Une erreur est survenue.";
+
+        if (!response.ok) {
+          throw new Error(message);
+        }
+
+        comment.textContent = message;
+        comment.classList.add(...deleteFormResultMessageCss.success);
+      } catch (error) {
+        deleteFormResult.textContent = error.message;
+        deleteFormResult.classList.add(deleteFormResultMessageCss.error);
+        deleteFormResult.classList.remove("d-none");
+        deleteButton.textContent = "Supprimer";
+        deleteButton.removeAttribute("disabled");
+      }
+    });
+  });
+}

--- a/public/js/front/comments.js
+++ b/public/js/front/comments.js
@@ -32,6 +32,12 @@ if (commentList) {
     deleteForm.addEventListener("submit", async (e) => {
       e.preventDefault();
 
+      const deleteConfirmed = confirm(
+        "Êtes-vous sûr(e) de vouloir supprimer ce commentaire ?"
+      );
+
+      if (!deleteConfirmed) return;
+
       deleteFormResult.classList.add("d-none");
 
       try {

--- a/src/Controller/Admin/CommentManagementController.php
+++ b/src/Controller/Admin/CommentManagementController.php
@@ -40,4 +40,67 @@ class CommentManagementController extends AdminController
             )
         );
     }
+
+    public function approveComment(int $id): void
+    {
+        $commentService = new CommentService();
+
+        $success = $commentService->approveComment($id);
+
+        $this->response->redirect("/admin/comments", 303);
+    }
+
+    public function rejectComment(int $id): void
+    {
+        $commentService = new CommentService();
+        $comment = $commentService->getComment($id);
+
+        if (!$comment) {
+            throw new NotFoundException("Le commentaire n'existe pas");
+        }
+
+        $formData = $this->request->body["commentReview"] ?? [];
+
+        if (!is_array($formData)) {
+            $formData = [];
+        }
+
+        $formResult = $commentService->checkCommentReviewFormData($formData);
+
+        if (in_array(true, array_values($formResult["errors"]))) {
+            $postService = new PostService();
+            $postId = $comment->getPostId();
+            $post = $postService->getPost($postId);
+
+            $this->response
+                ->setCode(400)
+                ->sendHTML(
+                    $this->twig->render(
+                        "admin/comment-review.html.twig",
+                        compact("comment", "post", "formResult")
+                    )
+                );
+            return;
+        }
+
+        $rejectReason = $formData["rejectReason"];
+
+        $success = $commentService->rejectComment($id, $rejectReason);
+
+        $formResult["success"] = $success;
+        $formResult["failure"] = !$success;
+
+        if (!$success) {
+            $this->response
+                ->setCode(500)
+                ->sendHTML(
+                    $this->twig->render(
+                        "admin/comment-review.html.twig",
+                        compact("comment", "post", "formResult")
+                    )
+                );
+        } else {
+            $this->response->redirect("/admin/comments", 303);
+        }
+    }
 }

--- a/src/Controller/Admin/CommentManagementController.php
+++ b/src/Controller/Admin/CommentManagementController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Controller\Admin;
+
+use App\Core\Exceptions\Client\NotFoundException;
+use App\Service\{PostService, CommentService};
+
+class CommentManagementController extends AdminController
+{
+    public function show(): void
+    {
+        $commentService = new CommentService();
+        $comments = $commentService->getCommentsToApprove();
+
+        $this->response->sendHTML(
+            $this->twig->render(
+                "admin/comment-management.html.twig",
+                compact("comments")
+            )
+        );
+    }
+
+    public function showReviewPage(int $id): void
+    {
+        $commentService = new CommentService();
+        $comment = $commentService->getComment($id);
+
+        if (!$comment) {
+            throw new NotFoundException("Le commentaire n'existe pas");
+        }
+
+        $postService = new PostService();
+        $postId = $comment->getPostId();
+        $post = $postService->getPost($postId);
+
+        $this->response->sendHTML(
+            $this->twig->render(
+                "admin/comment-review.html.twig",
+                compact("comment", "post")
+            )
+        );
+    }
+}

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -2,8 +2,7 @@
 
 namespace App\Controller\Admin;
 
-use App\Service\PostService;
-use App\Service\UserService;
+use App\Service\{PostService, UserService, CommentService};
 
 class DashboardController extends AdminController
 {
@@ -16,13 +15,16 @@ class DashboardController extends AdminController
     {
         $postService = new PostService();
         $userService = new UserService();
+        $commentService = new CommentService();
 
         $postCount = $postService->getPostCount(false);
         $userCount = $userService->getUserCount();
+        $commentCount = $commentService->getCommentCount();
 
         $stats = [
             "postCount" => $postCount,
             "userCount" => $userCount,
+            "commentCount" => $commentCount,
         ];
 
         $this->response->sendHTML(

--- a/src/Controller/CommentController.php
+++ b/src/Controller/CommentController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Controller;
+
+use App\Service\{CommentService, PostService, UserService};
+use App\Core\Exceptions\Client\NotFoundException;
+use App\Core\Exceptions\Client\Auth\UnauthorizedException;
+use App\Core\Exceptions\Client\Auth\ForbiddenException;
+
+class CommentController extends Controller
+{
+    public function redirectToPostPage(int $postId): void
+    {
+        $this->response->redirect("/posts/$postId");
+    }
+
+    public function createComment(int $postId): void
+    {
+        $postService = new PostService();
+
+        $post = $postService->getPost($postId);
+
+        if (!$post) {
+            throw new NotFoundException("Le post n'existe pas.");
+        }
+
+        $user = $this->request->user;
+
+        if (!$user) {
+            throw new UnauthorizedException();
+        }
+
+        if (!$user->getEmailVerified()) {
+            throw new ForbiddenException(
+                "Vous devez vérifier votre adresse e-mail pour poster des commentaires."
+            );
+        }
+
+        $commentService = new CommentService();
+
+        /** @var array */
+        $commentData = $this->request->body["commentForm"] ?? [];
+
+        if (gettype($commentData) !== "array") {
+            $commentData = [];
+        }
+
+        $commentFormResult = $commentService->checkFormData($commentData);
+
+        if (in_array(true, array_values($commentFormResult["errors"]))) {
+            $this->response
+                ->setCode(400)
+                ->sendHTML(
+                    $this->twig->render(
+                        "front/post-single.html.twig",
+                        compact("post", "commentFormResult")
+                    )
+                );
+            return;
+        }
+
+        $commentData["postId"] = $postId;
+        $commentData["author"] = $user;
+
+        $comment = $commentService->makeCommentObject($commentData);
+
+        $commentId = $commentService->createComment($comment);
+
+        $commentFormResult["success"] = true;
+        $commentFormResult["title"] = "";
+        $commentFormResult["body"] = "";
+
+        $this->response
+            ->setCode(201)
+            ->sendHTML(
+                $this->twig->render(
+                    "front/post-single.html.twig",
+                    compact("post", "commentFormResult")
+                )
+            );
+    }
+}

--- a/src/Controller/CommentController.php
+++ b/src/Controller/CommentController.php
@@ -67,8 +67,10 @@ class CommentController extends Controller
         $commentId = $commentService->createComment($comment);
 
         $commentFormResult["success"] = true;
-        $commentFormResult["title"] = "";
-        $commentFormResult["body"] = "";
+        $commentFormResult["values"] = [
+            "title" => "",
+            "body" => "",
+        ];
 
         $this->response
             ->setCode(201)

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -3,25 +3,21 @@
 namespace App\Entity;
 
 use App\Core\DateTime;
-use App\Entity\{User, Category};
+use App\Entity\User;
 
 /**
- * A blog post.
+ * A blog post comment.
  */
-class Post
+class Comment
 {
-    private int $id;
+    private ?int $id = null;
+    private int $postId;
     private DateTime $createdAt;
     private ?DateTime $updatedAt = null;
     private ?User $author = null;
-    private ?Category $category = null;
     private string $title = "";
-    private string $leadParagraph = "";
     private string $body = "";
-    private bool $isPublished = true;
-    private bool $commentsAllowed = true;
-    /** @var array<int, \App\Entity\Comment> */
-    private array $comments = [];
+    private bool $isApproved = false;
 
     public function __construct()
     {
@@ -32,9 +28,20 @@ class Post
         return $this->id;
     }
 
-    public function setId(int $id): static
+    public function setId(?int $id): static
     {
         $this->id = $id;
+        return $this;
+    }
+
+    public function getPostId(): int
+    {
+        return $this->postId;
+    }
+
+    public function setPostId(int $postId): static
+    {
+        $this->postId = $postId;
         return $this;
     }
 
@@ -85,17 +92,6 @@ class Post
         return $this;
     }
 
-    public function getCategory(): Category|null
-    {
-        return $this->category;
-    }
-
-    public function setCategory(?Category $category): static
-    {
-        $this->category = $category;
-        return $this;
-    }
-
     public function getTitle(): string
     {
         return $this->title;
@@ -104,17 +100,6 @@ class Post
     public function setTitle(string $title): static
     {
         $this->title = $title;
-        return $this;
-    }
-
-    public function getLeadParagraph(): string
-    {
-        return $this->leadParagraph;
-    }
-
-    public function setLeadParagraph(string $leadParagraph): static
-    {
-        $this->leadParagraph = $leadParagraph;
         return $this;
     }
 
@@ -129,42 +114,14 @@ class Post
         return $this;
     }
 
-    public function getIsPublished(): bool
+    public function getIsApproved(): bool
     {
-        return $this->isPublished;
+        return $this->isApproved;
     }
 
-    public function setIsPublished(bool|int $isPublished): static
+    public function setIsApproved(bool|int $isApproved): static
     {
-        $this->isPublished = (bool) $isPublished;
-        return $this;
-    }
-
-    public function getCommentsAllowed(): bool
-    {
-        return $this->commentsAllowed;
-    }
-
-    public function setCommentsAllowed(bool|int $commentsAllowed): static
-    {
-        $this->commentsAllowed = (bool) $commentsAllowed;
-        return $this;
-    }
-
-    /**
-     * @return array<int, \App\Entity\Comment>
-     */
-    public function getComments(): array
-    {
-        return $this->comments;
-    }
-
-    /**
-     * @param array<int, \App\Entity\Comment> $comments
-     */
-    public function setComments(array $comments): static
-    {
-        $this->comments = $comments;
+        $this->isApproved = (bool) $isApproved;
         return $this;
     }
 }

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -13,7 +13,6 @@ class Comment
     private ?int $id = null;
     private int $postId;
     private DateTime $createdAt;
-    private ?DateTime $updatedAt = null;
     private ?User $author = null;
     private string $title = "";
     private string $body = "";
@@ -56,26 +55,6 @@ class Comment
             $this->createdAt = new DateTime($createdAt);
         } elseif ($createdAt::class === DateTime::class) {
             $this->createdAt = $createdAt;
-        }
-
-        return $this;
-    }
-
-    public function getUpdatedAt(): DateTime|null
-    {
-        return $this->updatedAt;
-    }
-
-    public function setUpdatedAt(DateTime|string|null $updatedAt): static
-    {
-        if (is_null($updatedAt)) {
-            $this->updatedAt = null;
-        } elseif (gettype($updatedAt) === "string") {
-            $this->updatedAt = new DateTime($updatedAt);
-        } elseif (gettype($updatedAt) === "object" && $updatedAt::class === DateTime::class) {
-            $this->updatedAt = $updatedAt;
-        } else {
-            $this->updatedAt = null;
         }
 
         return $this;

--- a/src/Repository/CommentRepository.php
+++ b/src/Repository/CommentRepository.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Repository;
+
+use App\Core\Exceptions\Server\DB\DBException;
+use App\Entity\{Comment, User};
+
+class CommentRepository extends Repository
+{
+    /**
+     * Fetch a single comment based on its ID.
+     * 
+     * @param int  $id           ID of the comment.
+     * @param bool $approvedOnly Optional. Fetch only if the comment is approved. Default = `true`.
+     */
+    public function getComment(int $id): Comment | null
+    {
+        $db = $this->connection;
+
+        $req = $db->prepare(
+            "SELECT
+                c.postId,
+                c.createdAt,
+                c.updatedAt,
+                u.id as authorId,
+                u.name as authorName,
+                c.approved,
+                c.title,
+                c.body
+            FROM comments c
+            LEFT JOIN users u ON u.id = c.author
+            WHERE
+                c.id = :id"
+        );
+
+        $req->execute(compact("id"));
+
+        $commentRaw = $req->fetch();
+
+        if (!$commentRaw) {
+            return null;
+        }
+
+        $author = !is_null($commentRaw["authorId"]) ?
+            (new User)
+            ->setId($commentRaw["authorId"])
+            ->setName($commentRaw["authorName"])
+            : null;
+
+        $comment = (new Comment)
+            ->setId($id)
+            ->setPostId($commentRaw["postId"])
+            ->setCreatedAt($commentRaw["createdAt"])
+            ->setUpdatedAt($commentRaw["updatedAt"])
+            ->setAuthor($author)
+            ->setIsApproved($commentRaw["approved"])
+            ->setTitle($commentRaw["title"])
+            ->setBody($commentRaw["body"]);
+
+        return $comment;
+    }
+
+    /**
+     * Fetch the comments of a blog post.
+     * 
+     * @param int  $postId       ID of the post to fetch the comments for.
+     * @param bool $approvedOnly Optional. Fetch only approved comments. Default = `true`.
+     * 
+     * @return array<int, \App\Entity\Comment> 
+     */
+    public function getPostComments(int $postId, bool $approvedOnly = true): array
+    {
+        $db = $this->connection;
+
+        $approvedOnlySql = $approvedOnly ? "AND approved = 1" : "";
+
+        $req = $db->prepare(
+            "SELECT
+                c.id,
+                c.title,
+                c.body,
+                u.id as authorId,
+                u.name as authorName,
+                c.approved,
+                c.createdAt,
+                c.updatedAt
+            FROM comments c
+            LEFT JOIN users u ON u.id = c.author
+            WHERE c.postId = :postId
+            $approvedOnlySql
+            ORDER BY c.createdAt ASC"
+        );
+
+        $req->execute(compact("postId"));
+
+        $commentsRaw = $req->fetchAll();
+
+        if ($commentsRaw === false) {
+            throw new DBException("Erreur lors de la récupération des commentaires.");
+        }
+
+        $comments = array_map(function ($commentRaw) use ($postId) {
+            $author = !is_null($commentRaw["authorId"]) ?
+                (new User)
+                ->setId($commentRaw["authorId"])
+                ->setName($commentRaw["authorName"])
+                : null;
+
+            $comment = (new Comment)
+                ->setId($commentRaw["id"])
+                ->setPostId($postId)
+                ->setTitle($commentRaw["title"])
+                ->setBody($commentRaw["body"])
+                ->setAuthor($author)
+                ->setIsApproved($commentRaw["approved"])
+                ->setCreatedAt($commentRaw["createdAt"])
+                ->setUpdatedAt($commentRaw["updatedAt"]);
+
+            return $comment;
+        }, $commentsRaw);
+
+        $req->closeCursor();
+
+        return $comments;
+    }
+
+    /**
+     * Fetch the comments to be approved.
+     * 
+     * @return array<int, \App\Entity\Comment> 
+     */
+    public function getCommentsToApprove(): array
+    {
+        $db = $this->connection;
+
+        $req = $db->prepare(
+            "SELECT
+                c.id,
+                c.postId,
+                c.title,
+                c.body,
+                u.id as authorId,
+                u.name as authorName,
+                c.createdAt,
+                c.updatedAt
+            FROM comments c
+            LEFT JOIN posts p ON p.id = c.postId
+            LEFT JOIN users u ON u.id = p.author
+            WHERE approved = 0
+            ORDER BY c.createdAt ASC"
+        );
+
+        $req->execute();
+
+        $commentsRaw = $req->fetchAll();
+
+        if ($commentsRaw === false) {
+            throw new DBException("Erreur lors de la récupération des commentaires.");
+        }
+
+        $comments = array_map(function ($commentRaw) {
+            $author = !is_null($commentRaw["authorId"]) ?
+                (new User)
+                ->setId($commentRaw["authorId"])
+                ->setName($commentRaw["authorName"])
+                : null;
+
+            $comment = (new Comment)
+                ->setId($commentRaw["id"])
+                ->setPostId($commentRaw["postId"])
+                ->setTitle($commentRaw["title"])
+                ->setBody($commentRaw["body"])
+                ->setAuthor($author)
+                ->setCreatedAt($commentRaw["createdAt"])
+                ->setUpdatedAt($commentRaw["updatedAt"]);
+
+            return $comment;
+        }, $commentsRaw);
+
+        $req->closeCursor();
+
+        return $comments;
+    }
+
+    /**
+     * Get the amount of blog posts in the database.
+     * 
+     * @param bool $approvedOnly Optional. Count only published posts. Default = `true`.
+     * @param ?int $postId       Optional. Count posts related to a blog post. Default = `null`.  
+     *                           If set to `null`, count the comments for all posts.
+     */
+    public function getCommentCount(?int $postId = null): array|false
+    {
+        $db = $this->connection;
+
+        $postSql = $postId ? "AND postId = :postId" : "";
+
+        $req = $db->prepare(
+            "SELECT
+                (SELECT COUNT(*) FROM comments WHERE 1 $postSql) as total,
+                (SELECT COUNT(*) FROM comments WHERE approved = 1 $postSql) as approved,
+                (SELECT COUNT(*) FROM comments WHERE approved = 0 $postSql) as notApproved
+            "
+        );
+
+        $req->execute($postId ? compact("postId") : null);
+
+        /** @var array|false */
+        $count = $req->fetch();
+
+        return $count;
+    }
+
+    /**
+     * @return int ID of the newly created comment.
+     */
+    public function createComment(Comment $comment): int
+    {
+        $db = $this->connection;
+
+
+        try {
+            $db->beginTransaction();
+
+            $req = $db->prepare(
+                "INSERT INTO comments
+                SET
+                    postId = :postId,
+                    author = :author,
+                    title = :title,
+                    body = :body,
+                    approved = 0"
+            );
+
+            $req->execute([
+                "postId" =>  $comment->getPostId(),
+                "author" =>  $comment->getAuthor()->getId(),
+                "title" => $comment->getTitle(),
+                "body" =>  $comment->getBody(),
+            ]);
+
+            $lastInsertId = $db->lastInsertId();
+
+            $db->commit();
+        } catch (\PDOException $e) {
+            $db->rollBack();
+            throw new DBException("Erreur lors de la création du commentaire.", previous: $e);
+        }
+
+        return (int) $lastInsertId;
+    }
+}

--- a/src/Repository/CommentRepository.php
+++ b/src/Repository/CommentRepository.php
@@ -23,6 +23,7 @@ class CommentRepository extends Repository
                 c.createdAt,
                 u.id as authorId,
                 u.name as authorName,
+                u.email as authorEmail,
                 c.approved,
                 c.title,
                 c.body
@@ -44,6 +45,7 @@ class CommentRepository extends Repository
             (new User)
             ->setId($commentRaw["authorId"])
             ->setName($commentRaw["authorName"])
+            ->setEmail($commentRaw["authorEmail"])
             : null;
 
         $comment = (new Comment)
@@ -189,6 +191,20 @@ class CommentRepository extends Repository
     }
 
     /**
+     * @return bool `true` if the comment was deleted, `false` otherwise.
+     */
+    public function deleteComment(int $id): bool
+    {
+        $db = $this->connection;
+
+        $req = $db->prepare("DELETE FROM comments WHERE id = :id");
+
+        $success = $req->execute(["id" => $id]);
+
+        return $success;
+    }
+
+    /**
      * Fetch the comments to be approved.
      * 
      * @return array<int, \App\Entity\Comment> 
@@ -242,5 +258,20 @@ class CommentRepository extends Repository
         $req->closeCursor();
 
         return $comments;
+    }
+
+    public function approveComment(int $id): bool
+    {
+        $db = $this->connection;
+
+        $req = $db->prepare(
+            "UPDATE comments
+            SET approved = 1
+            WHERE id = :id"
+        );
+
+        $success = $req->execute(compact("id"));
+
+        return $success;
     }
 }

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -27,10 +27,11 @@ class PostRepository extends Repository
                 u.name as authorName,
                 c.id as categoryId,
                 c.name as categoryName,
-                p.published,
                 p.title,
                 p.leadParagraph,
-                p.body
+                p.body,
+                p.published,
+                p.commentsAllowed
             FROM posts p
             LEFT JOIN users u ON u.id = p.author
             LEFT JOIN categories c ON c.id = p.category
@@ -66,6 +67,7 @@ class PostRepository extends Repository
             ->setAuthor($author)
             ->setCategory($category)
             ->setIsPublished($postRaw["published"])
+            ->setCommentsAllowed($postRaw["commentsAllowed"])
             ->setTitle($postRaw["title"])
             ->setLeadParagraph($postRaw["leadParagraph"])
             ->setBody($postRaw["body"]);
@@ -99,7 +101,8 @@ class PostRepository extends Repository
                 c.name as categoryName,
                 p.title,
                 p.leadParagraph,
-                p.published
+                p.published,
+                p.commentsAllowed
             FROM posts p
             LEFT JOIN users u ON u.id = p.author
             LEFT JOIN categories c ON c.id = p.category
@@ -140,6 +143,7 @@ class PostRepository extends Repository
                 ->setAuthor($author)
                 ->setCategory($category)
                 ->setIsPublished($postRaw["published"])
+                ->setCommentsAllowed($postRaw["commentsAllowed"])
                 ->setTitle($postRaw["title"])
                 ->setLeadParagraph($postRaw["leadParagraph"]);
 
@@ -183,16 +187,18 @@ class PostRepository extends Repository
                 body = :body,
                 author = :author,
                 category = :category,
-                published = :published"
+                published = :published,
+                commentsAllowed = :commentsAllowed"
         );
 
         $req->execute([
             "title" => $data["title"],
             "leadParagraph" => $data["leadParagraph"],
             "body" => $data["body"],
+            "author" => $data["author"],
             "category" => (int) ($data["category"] ?? null) ?: null,
             "published" => (int) isset($data["isPublished"]),
-            "author" => $data["author"],
+            "commentsAllowed" => (int) isset($data["commentsAllowed"]),
         ]);
 
         $lastInsertId = $db->lastInsertId();
@@ -214,6 +220,7 @@ class PostRepository extends Repository
                 body = :body,
                 category = :category,
                 published = :published,
+                commentsAllowed = :commentsAllowed,
                 updatedAt = CURRENT_TIMESTAMP
             WHERE
                 id = :id"
@@ -226,6 +233,7 @@ class PostRepository extends Repository
             "body" => $data["body"],
             "category" => (int) ($data["category"] ?? null) ?: null,
             "published" => (int) isset($data["isPublished"]),
+            "commentsAllowed" => (int) isset($data["commentsAllowed"]),
         ]);
     }
 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -377,7 +377,8 @@ class UserRepository extends Repository
         $req = $db->prepare(
             "SELECT
                 u.id,
-                u.name
+                u.name,
+                u.email
             FROM users u
             WHERE u.id = :id"
         );

--- a/src/Service/CommentService.php
+++ b/src/Service/CommentService.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Service;
+
+use App\Repository\{CommentRepository, UserRepository};
+use App\Entity\{Comment, User};
+
+class CommentService
+{
+    private CommentRepository $commentRepository;
+    private UserRepository $userRepository;
+
+    public function __construct()
+    {
+        $this->commentRepository = new CommentRepository();
+        $this->userRepository = new UserRepository();
+    }
+
+    public function makeCommentObject(array $commentData): Comment
+    {
+        $author = $commentData["author"] ?
+            ($commentData["author"] instanceof User
+                ? $commentData["author"]
+                : $this->userRepository->getAuthor($commentData["author"]))
+            : null;
+
+        $comment = (new Comment())
+            ->setId($commentData["id"] ?? null)
+            ->setPostId($commentData["postId"])
+            ->setCreatedAt($commentData["createdAt"] ?? "now")
+            ->setUpdatedAt($commentData["updatedAt"] ?? null)
+            ->setAuthor($author)
+            ->setIsApproved($commentData["approved"] ?? false)
+            ->setTitle($commentData["title"] ?? "")
+            ->setBody($commentData["body"] ?? "");
+
+        return $comment;
+    }
+
+    /**
+     * Get a single blog post based on its ID.
+     * 
+     * @param int $id ID of the comment.
+     */
+    public function getComment(int $id): Comment | null
+    {
+        return $this->commentRepository->getComment($id);
+    }
+
+    /**
+     * @return array<int, \App\Entity\Comment>
+     */
+    public function getPostComments(int $postId): array
+    {
+        return $this->commentRepository->getPostComments($postId);
+    }
+
+    /**
+     * Get the amount of blog posts in the database.
+     * 
+     * @param bool $approvedOnly Optional. Count only published posts. Default = `true`.
+     * @param ?int $postId       Optional. Count posts related to a blog post. Default = `null`.  
+     *                           If set to `null`, count the comments for all posts.
+     */
+    public function getCommentCount(?int $postId = null): array|false
+    {
+        return $this->commentRepository->getCommentCount($postId);
+    }
+
+    public function checkFormData(array $formData): array
+    {
+        $titleIsString = gettype($formData["title"] ?? null) === "string";
+        $bodyIsString = gettype($formData["body"] ?? null) === "string";
+
+        $title = $titleIsString ? $formData["title"] : "";
+        $body = $bodyIsString ? $formData["body"] : "";
+
+        $titleMissing = $title === "";
+        $titleTooLong = mb_strlen($title) > 255;
+        $bodyMissing = $body === "";
+        $bodyTooLong = strlen($body) > pow(2, 16) + 2; // MySQL TEXT limit;
+
+        $formResult = [
+            "success" => false,
+            "failure" => false,
+            "values" => compact(
+                "title",
+                "body",
+            ),
+            "errors" => compact(
+                "titleMissing",
+                "titleTooLong",
+                "bodyMissing",
+                "bodyTooLong",
+            ),
+        ];
+
+        return $formResult;
+    }
+
+    /**
+     * @return int ID of the newly created comment.
+     */
+    public function createComment(Comment $comment): int
+    {
+        return $this->commentRepository->createComment($comment);
+    }
+
+    /**
+     * Get the comments to be approved.
+     * 
+     * @return array<int, \App\Entity\Comment>
+     */
+    public function getCommentsToApprove(): array
+    {
+        return $this->commentRepository->getCommentsToApprove();
+    }
+}

--- a/src/Service/CommentService.php
+++ b/src/Service/CommentService.php
@@ -115,6 +115,14 @@ class CommentService
     }
 
     /**
+     * @return bool `true` if the comment was deleted, `false` otherwise.
+     */
+    public function deleteComment(int $id): bool
+    {
+        return $this->commentRepository->deleteComment($id);
+    }
+
+    /**
      * Get the comments to be approved.
      * 
      * @return array<int, \App\Entity\Comment>

--- a/src/Service/CommentService.php
+++ b/src/Service/CommentService.php
@@ -102,6 +102,15 @@ class CommentService
      */
     public function createComment(Comment $comment): int
     {
+        $safeTitle = htmlspecialchars($comment->getTitle(), ENT_NOQUOTES);
+        $safeBody = htmlspecialchars($comment->getBody(), ENT_NOQUOTES);
+
+        dd($comment);
+
+        $comment
+            ->setTitle($safeTitle)
+            ->setBody($safeBody);
+
         return $this->commentRepository->createComment($comment);
     }
 

--- a/src/Service/CommentService.php
+++ b/src/Service/CommentService.php
@@ -28,7 +28,6 @@ class CommentService
             ->setId($commentData["id"] ?? null)
             ->setPostId($commentData["postId"])
             ->setCreatedAt($commentData["createdAt"] ?? "now")
-            ->setUpdatedAt($commentData["updatedAt"] ?? null)
             ->setAuthor($author)
             ->setIsApproved($commentData["approved"] ?? false)
             ->setTitle($commentData["title"] ?? "")

--- a/src/Service/EmailService.php
+++ b/src/Service/EmailService.php
@@ -9,8 +9,8 @@ use App\Core\ErrorLogger;
 class EmailService
 {
     private PHPMailer $mail;
-    private string $fromAddress;
-    private string $fromName = "";
+    private string $fromAddress = "";
+    private string $fromName =  "";
     private array $to = [];
     private array $cc = [];
     private array $bcc = [];
@@ -43,6 +43,9 @@ class EmailService
             $this->mail->Port       = $_ENV["SMTP_PORT"];                  //TCP port to connect to; use 587 if you have set `SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS`
 
             // From
+            if (!$this->fromAddress && !$this->fromName) {
+                $this->setFrom($_ENV["MAIL_SENDER_EMAIL"], $_ENV["MAIL_SENDER_NAME"]);
+            }
             $this->mail->setFrom($this->fromAddress, $this->fromName);
 
             //Recipients (To)

--- a/src/Service/PostService.php
+++ b/src/Service/PostService.php
@@ -4,6 +4,7 @@ namespace App\Service;
 
 use App\Repository\PostRepository;
 use App\Entity\Post;
+use App\Service\CommentService;
 
 class PostService
 {
@@ -17,12 +18,20 @@ class PostService
     /**
      * Get a single blog post based on its ID.
      * 
-     * @param int $id             ID of the blog post.
+     * @param int  $id            ID of the blog post.
      * @param bool $publishedOnly Optional. Fetch only if the post is published. Default = `true`.
      */
-    public function getPost(int $id, bool $publishedOnly = true): Post | null
+    public function getPost(int $id, bool $publishedOnly = true, bool $withComments = true): Post | null
     {
-        return $this->postRepository->getPost($id, $publishedOnly);
+        $post = $this->postRepository->getPost($id, $publishedOnly);
+
+        if ($post && $withComments) {
+            $commentService = new CommentService();
+            $comments = $commentService->getPostComments($id);
+            $post->setComments($comments);
+        }
+
+        return $post;
     }
 
     /**

--- a/templates/admin/comment-management.html.twig
+++ b/templates/admin/comment-management.html.twig
@@ -63,15 +63,7 @@
 									<td class="align-middle">
 										<div class="row text-center">
 											<div class="col">
-												<a href="/admin/comments/{{ comment.id }}" class="text-secondary font-weight-normal text-xs" title="Modifier le commentaire">
-													Modifier
-												</a>
-											</div>
-											<div class="col">
-												<button type="button" class="btn btn-outline-danger btn-sm mb-0" title="Supprimer le commentaire" data-delete>
-													<span class="text">Supprimer</span>
-													<span class="spinner spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
-												</button>
+												<a href="/admin/comments/{{ comment.id }}" class="btn btn-outline-info btn-sm mb-0" title="Vérifier le commentaire">Vérifier</a>
 											</div>
 										</div>
 									</td>

--- a/templates/admin/comment-management.html.twig
+++ b/templates/admin/comment-management.html.twig
@@ -1,0 +1,90 @@
+{% extends "admin/layout.html.twig" %}
+
+{% block stylesheets %}
+	<link rel="stylesheet" href="/assets/css/form.css">
+{% endblock %}
+
+{% set breadcrumbs = [
+	{
+		"name": "Gestion des commentaires"
+	}
+] %}
+
+
+{% block body %}
+	<h1 class="mb-3">Gestion des commentaires</h1>
+
+	<div class="card">
+		<div class="table-responsive">
+			<div class="dataTable-wrapper">
+				<div class="dataTable-container">
+					<table id="datatable" class="table align-items-center mb-0 dataTable-table">
+						<thead>
+							<tr class="d-none d-md-table-row">
+								<th class="text-uppercase text-secondary text-xxs font-weight-bolder opacity-7">Date</th>
+								<th class="text-uppercase text-secondary text-xxs font-weight-bolder opacity-7">Auteur</th>
+								<th class="text-uppercase text-secondary text-xxs font-weight-bolder opacity-7">Titre</th>
+								<th class="text-secondary opacity-7"></th>
+							</tr>
+						</thead>
+						<tbody>
+							{% for comment in comments %}
+								<tr data-comment-id="{{ comment.id }}">
+									<td>
+										<p class="text-xs mb-0">{{ comment.createdAt|format_date("short", locale="fr") }}</p>
+										<div class="d-md-none mt-1">
+											<p class="text-xs text-secondary mb-0">
+												{{ comment.author }}
+											</p>
+											<p class="text-xs text-secondary mb-0">
+												{{ comment.title }}
+											</p>
+										</div>
+									</td>
+
+									<td class="d-none d-md-table-cell">
+										<div class="d-flex px-2 py-1">
+											<div class="d-flex flex-column justify-content-center">
+												<h6 class="mb-0 text-xs">{{ comment.author }}</h6>
+
+											</div>
+										</div>
+									</td>
+
+									<td class="d-none d-md-table-cell">
+										<div class="d-flex px-2 py-1">
+											<div class="d-flex flex-column justify-content-center">
+												<h6 class="mb-0 text-xs">{{ comment.title }}</h6>
+
+											</div>
+										</div>
+									</td>
+
+									<td class="align-middle">
+										<div class="row text-center">
+											<div class="col">
+												<a href="/admin/comments/{{ comment.id }}" class="text-secondary font-weight-normal text-xs" title="Modifier le commentaire">
+													Modifier
+												</a>
+											</div>
+											<div class="col">
+												<button type="button" class="btn btn-outline-danger btn-sm mb-0" title="Supprimer le commentaire" data-delete>
+													<span class="text">Supprimer</span>
+													<span class="spinner spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+												</button>
+											</div>
+										</div>
+									</td>
+
+								</tr>
+							{% endfor %}
+						</tbody>
+					</table>
+				</div>
+			</div>
+
+
+		</div>
+	</div>
+
+{% endblock %}

--- a/templates/admin/comment-review.html.twig
+++ b/templates/admin/comment-review.html.twig
@@ -33,32 +33,48 @@
 		<div class="container px-4 px-lg-5">
 			<div class="row gx-4 gx-lg-5 justify-content-center">
 				<div class="col-md-10 col-lg-8 col-xl-7 mb-5">
-					<form id="commentForm" method="post" action="">
-						<div class="input-group input-group-static">
-							<label for="title">Titre</label>
-							<input type="text" id="title" name="post[title]" class="form-control" maxlength="255" placeholder="Titre" value="{{ comment.title }}" required/>
-							{% if formResult.errors.titleMissing %}
-								<div class="invalid-feedback">Le titre est requis.</div>
-							{% endif %}
-							{% if formResult.errors.titleTooLong %}
-								<div class="invalid-feedback">Le titre ne doit pas dépasser 255 caractères.</div>
-							{% endif %}
-						</div>
 
-						<div class="input-group input-group-static mt-4">
-							<label for="body">Corps du commentaire</label>
-							<textarea class="form-control" id="body" name="post[body]" placeholder="Entrez le corps du post" style="height: 10rem" required>{{ comment.body }}</textarea>
-						</div>
-
-						<div class="form-check form-switch mt-3">
-							<label for="isApproved" class="form-check-label">Approuver ce commentaire</label>
-							<input type="checkbox" id="isApproved" name="post[isApproved]" class="form-check-input" {{ post.isApproved ? "checked" }}/>
-						</div>
-
-						<button class="btn btn-primary text-uppercase mt-5" id="submitButton" type="submit">Enregistrer</button>
+					<div class="mb-3">
+						<div class="fw-bold">Post</div>
+						<span>{{ post.title }}</span>
+						(<a href="/posts/{{ post.id }}" target="_blank">voir le post</a>)
 					</div>
+
+					<div class="mb-3">
+						<div class="fw-bold">Titre</div>
+						<span>{{ comment.title }}</span>
+					</div>
+
+					<div class="mb-3">
+						<div class="fw-bold">Corps</div>
+						<span>{{ comment.body }}</span>
+					</div>
+
+					<form id="commentReviewForm" method="post" action="">
+
+						<div class="mt-4">
+							<button class="btn btn-success text-uppercase" id="approveButton" type="submit" formaction="/admin/comments/{{ comment.id }}/approve">Approuver</button>
+							<button class="btn btn-danger text-uppercase" id="rejectButton" type="submit" formaction="/admin/comments/{{ comment.id }}/reject">Rejeter</button>
+						</div>
+
+						<div class="input-group input-group-dynamic mt-3">
+							<label for="rejectReason" class="form-label">Raison du rejet</label>
+							<input type="text" class="form-control" id="rejectReason" name="commentReview[rejectReason]">
+							{% if formResult.errors.rejectReasonMissing %}
+								<div class="invalid-feedback">La raison du rejet est obligatoire.</div>
+							{% endif %}
+						</div>
+
+						<!-- Submit error message-->
+						{% if formResult.failure %}
+							<div id="submitErrorMessage">
+								<div class="text-center text-danger mb-3">L'identifiant et/ou le mot de passe est invalide.</div>
+							</div>
+						{% endif %}
+
+					</form>
 				</div>
 			</div>
-		</form>
+		</div>
 	</main>
 {% endblock %}

--- a/templates/admin/comment-review.html.twig
+++ b/templates/admin/comment-review.html.twig
@@ -47,7 +47,7 @@
 
 					<div class="mb-3">
 						<div class="fw-bold">Corps</div>
-						<span>{{ comment.body }}</span>
+						<span>{{ comment.body|nl2br }}</span>
 					</div>
 
 					<form id="commentReviewForm" method="post" action="">

--- a/templates/admin/comment-review.html.twig
+++ b/templates/admin/comment-review.html.twig
@@ -1,0 +1,64 @@
+{% extends "admin/layout.html.twig" %}
+
+{% block stylesheets %}
+	<link rel="stylesheet" href="/assets/css/form.css">
+{% endblock %}
+
+{% set breadcrumbs = [
+	{
+		"href": "/admin/comments",
+		"name": "Gestion des commentaires",
+		"title": "Gestion des commentaires"
+	},
+	{
+		"name": "Revue de commentaire"
+	},
+] %}
+
+
+{% block body %}
+	<header class="masthead page-heading">
+		<div class="container position-relative px-4 px-lg-5">
+			<div class="row gx-4 gx-lg-5 gy-4 justify-content-center">
+				<div class="col-md-10 col-lg-8 col-xl-7 mb-3">
+					<div class="post-heading">
+						<h1>Revue de commentaire</h1>
+					</div>
+				</div>
+			</div>
+		</div>
+	</header>
+
+	<main>
+		<div class="container px-4 px-lg-5">
+			<div class="row gx-4 gx-lg-5 justify-content-center">
+				<div class="col-md-10 col-lg-8 col-xl-7 mb-5">
+					<form id="commentForm" method="post" action="">
+						<div class="input-group input-group-static">
+							<label for="title">Titre</label>
+							<input type="text" id="title" name="post[title]" class="form-control" maxlength="255" placeholder="Titre" value="{{ comment.title }}" required/>
+							{% if formResult.errors.titleMissing %}
+								<div class="invalid-feedback">Le titre est requis.</div>
+							{% endif %}
+							{% if formResult.errors.titleTooLong %}
+								<div class="invalid-feedback">Le titre ne doit pas dépasser 255 caractères.</div>
+							{% endif %}
+						</div>
+
+						<div class="input-group input-group-static mt-4">
+							<label for="body">Corps du commentaire</label>
+							<textarea class="form-control" id="body" name="post[body]" placeholder="Entrez le corps du post" style="height: 10rem" required>{{ comment.body }}</textarea>
+						</div>
+
+						<div class="form-check form-switch mt-3">
+							<label for="isApproved" class="form-check-label">Approuver ce commentaire</label>
+							<input type="checkbox" id="isApproved" name="post[isApproved]" class="form-check-input" {{ post.isApproved ? "checked" }}/>
+						</div>
+
+						<button class="btn btn-primary text-uppercase mt-5" id="submitButton" type="submit">Enregistrer</button>
+					</div>
+				</div>
+			</div>
+		</form>
+	</main>
+{% endblock %}

--- a/templates/admin/dashboard.html.twig
+++ b/templates/admin/dashboard.html.twig
@@ -34,9 +34,29 @@
 						<h4 class="mb-0">{{ stats.postCount }}</h4>
 					</div>
 				</div>
-
 				<hr class="dark horizontal my-0">
 				<div class="card-footer p-3"></div>
+			</div>
+		</div>
+
+		<div class="col-lg-3 col-md-6 col-sm-6 mt-lg-0 mt-4">
+			<div class="card  mb-2">
+				<div class="card-header p-3 pt-2 bg-transparent">
+					<div class="icon icon-lg icon-shape bg-gradient-info shadow-info text-center border-radius-xl mt-n4 position-absolute">
+						<i class="material-icons opacity-10">comment</i>
+					</div>
+					<div class="text-end pt-1">
+						<p class="text-sm mb-0 text-capitalize ">Commentaires</p>
+						<h4 class="mb-0 ">{{ stats.commentCount.total ?? "Erreur" }}</h4>
+					</div>
+				</div>
+				<hr class="horizontal my-0 dark">
+				<div class="card-footer p-3">
+					<p class="mb-0">
+						Dont
+						<span class="text-dark text-sm font-weight-bolder">{{ stats.commentCount.notApproved ?? "Erreur" }}</span>
+						à approuver</p>
+				</div>
 			</div>
 		</div>
 
@@ -51,24 +71,7 @@
 						<h4 class="mb-0">{{ stats.userCount }}</h4>
 					</div>
 				</div>
-
 				<hr class="dark horizontal my-0">
-				<div class="card-footer p-3"></div>
-			</div>
-		</div>
-
-		<div class="col-lg-3 col-md-6 col-sm-6 mt-lg-0 mt-4">
-			<div class="card  mb-2">
-				<div class="card-header p-3 pt-2 bg-transparent">
-					<div class="icon icon-lg icon-shape bg-gradient-info shadow-info text-center border-radius-xl mt-n4 position-absolute">
-						<i class="material-icons opacity-10">comment</i>
-					</div>
-					<div class="text-end pt-1">
-						<p class="text-sm mb-0 text-capitalize ">Commentaires</p>
-						<h4 class="mb-0 ">{{ stats.commentCount ?? 0 }}</h4>
-					</div>
-				</div>
-				<hr class="horizontal my-0 dark">
 				<div class="card-footer p-3"></div>
 			</div>
 		</div>

--- a/templates/admin/includes/sidebar.html.twig
+++ b/templates/admin/includes/sidebar.html.twig
@@ -34,6 +34,15 @@
 			</li>
 
 			<li class="nav-item">
+				<a class="nav-link text-white " href="/admin/comments">
+					<div class="text-white text-center me-2 d-flex align-items-center justify-content-center">
+						<i class="material-icons opacity-10">comment</i>
+					</div>
+					<span class="nav-link-text ms-1">Commentaires</span>
+				</a>
+			</li>
+
+			<li class="nav-item">
 				<a class="nav-link text-white " href="/admin/users">
 					<div class="text-white text-center me-2 d-flex align-items-center justify-content-center">
 						<i class="material-icons opacity-10">person</i>

--- a/templates/admin/post-edit.html.twig
+++ b/templates/admin/post-edit.html.twig
@@ -97,6 +97,11 @@
 							<input type="checkbox" id="isPublished" name="post[isPublished]" class="form-check-input" {{ post.isPublished ? "checked" }}/>
 						</div>
 
+						<div class="form-check form-switch mt-3">
+							<label for="commentsAllowed" class="form-check-label">Autoriser les commentaires</label>
+							<input type="checkbox" id="commentsAllowed" name="post[commentsAllowed]" class="form-check-input" {{ post.commentsAllowed ? "checked" }}/>
+						</div>
+
 						<button class="btn btn-primary text-uppercase mt-5" id="submitButton" type="submit">Enregistrer</button>
 					</div>
 				</div>

--- a/templates/front/includes/comment.html.twig
+++ b/templates/front/includes/comment.html.twig
@@ -1,0 +1,14 @@
+<li class="list-group-item" id="comment-{{ comment.id }}">
+	<div>
+		{{ comment.author }}, le
+		{{ comment.createdAt|format_date("short", locale="fr") }}
+	</div>
+
+	<div class="fw-bold">
+		{{ comment.title }}
+	</div>
+
+	<div>
+		{{ comment.body }}
+	</div>
+</li>

--- a/templates/front/includes/comment.html.twig
+++ b/templates/front/includes/comment.html.twig
@@ -9,6 +9,6 @@
 	</div>
 
 	<div>
-		{{ comment.body }}
+		{{ comment.body|nl2br }}
 	</div>
 </li>

--- a/templates/front/includes/comment.html.twig
+++ b/templates/front/includes/comment.html.twig
@@ -12,7 +12,7 @@
 		{{ comment.body|nl2br }}
 	</div>
 
-	{% if comment.author.id == user.id %}
+	{% if comment.author.id == user.id or user.isAdmin %}
 		<form action="/posts/{{ post.id }}/comments/{{ comment.id }}/delete#comments" method="post" class="js-delete-form">
 			<button type="submit" class="btn btn-danger btn-sm" style="--bs-btn-padding-y: 0.25rem; --bs-btn-padding-x: .5rem; --bs-btn-font-size: .75rem;">Supprimer</button>
 		</form>

--- a/templates/front/includes/comment.html.twig
+++ b/templates/front/includes/comment.html.twig
@@ -1,4 +1,4 @@
-<li class="list-group-item" id="comment-{{ comment.id }}">
+<li class="list-group-item js-comment" id="comment-{{ comment.id }}" data-comment-id="{{ comment.id }}">
 	<div>
 		{{ comment.author }}, le
 		{{ comment.createdAt|format_date("short", locale="fr") }}
@@ -11,4 +11,13 @@
 	<div>
 		{{ comment.body|nl2br }}
 	</div>
+
+	{% if comment.author.id == user.id %}
+		<form action="/posts/{{ post.id }}/comments/{{ comment.id }}/delete#comments" method="post" class="js-delete-form">
+			<button type="submit" class="btn btn-danger btn-sm" style="--bs-btn-padding-y: 0.25rem; --bs-btn-padding-x: .5rem; --bs-btn-font-size: .75rem;">Supprimer</button>
+		</form>
+
+		<div class="d-none js-delete-form-result"></div>
+	{% endif %}
+
 </li>

--- a/templates/front/post-single.html.twig
+++ b/templates/front/post-single.html.twig
@@ -57,7 +57,7 @@
 	<div class="container px-4 px-lg-5 my-3">
 		<div class="row gx-4 gx-lg-5 justify-content-center">
 			<div class="col-md-10 col-lg-8 col-xl-7">
-				<h2>Commentaires</h2>
+				<h2 id="comments">Commentaires</h2>
 			</div>
 		</div>
 
@@ -78,7 +78,7 @@
 						{% if user %}
 							{% if user.emailVerified %}
 								<div class="row gx-4 gx-lg-5">
-									<form id="commentForm" action="/posts/{{ post.id }}/createComment#commentForm" method="post">
+									<form id="commentForm" action="/posts/{{ post.id }}/comments/create#commentForm" method="post">
 										<div class="form-floating">
 											<input type="text" class="form-control" id="title" name="commentForm[title]" placeholder="Entrez votre nom..." value="{{ commentFormResult.values.title }}" maxlength="255" required/>
 											<label for="title">Titre</label>

--- a/templates/front/post-single.html.twig
+++ b/templates/front/post-single.html.twig
@@ -5,6 +5,10 @@
 	<link rel="stylesheet" href="/assets/css/form.css">
 {% endblock %}
 
+{% block javascript %}
+	<script defer src="/assets/js/front/comments.js"></script>
+{% endblock %}
+
 {% block body %}
 	<!-- Page Header-->
 	<header class="masthead" style="background-image: url('/assets/img/home-bg.jpg')">
@@ -61,12 +65,28 @@
 			</div>
 		</div>
 
+		{% if deleteCommentFormResult %}
+			<div class="row gx-4 gx-lg-5 my-4 justify-content-center">
+				<div class="col-md-10 col-lg-8 col-xl-7">
+
+					{% if deleteCommentFormResult.success %}
+						<span class="text-success">{{ deleteCommentFormResult.message }}</span>
+					{% endif %}
+
+					{% if deleteCommentFormResult.failure %}
+						<span class="invalid-feedback">{{ deleteCommentFormResult.message }}</span>
+					{% endif %}
+
+				</div>
+			</div>
+		{% endif %}
+
 		<div class="container px-4 px-lg-5">
 			{% if post.commentsAllowed %}
 				<div class="row gx-4 gx-lg-5 justify-content-center">
-					<div class="col-md-10 col-lg-8 col-xl-7">
+					<div class="col-md-10 col-lg-8 col-xl-7 p-0">
 						{% if post.comments|length > 0 %}
-							<ul class="list-group list-group-flush">
+							<ul class="list-group list-group-flush" id="commentList">
 								{% for comment in post.comments %}
 									{% include "front/includes/comment.html.twig" %}
 								{% endfor %}
@@ -77,7 +97,7 @@
 
 						{% if user %}
 							{% if user.emailVerified %}
-								<div class="row gx-4 gx-lg-5">
+								<div class="row gx-4 gx-lg-5 my-4">
 									<form id="commentForm" action="/posts/{{ post.id }}/comments/create#commentForm" method="post">
 										<div class="form-floating">
 											<input type="text" class="form-control" id="title" name="commentForm[title]" placeholder="Entrez votre nom..." value="{{ commentFormResult.values.title }}" maxlength="255" required/>

--- a/templates/front/post-single.html.twig
+++ b/templates/front/post-single.html.twig
@@ -2,6 +2,7 @@
 
 {% block stylesheets %}
 	<link rel="stylesheet" href="/assets/css/front/common.css">
+	<link rel="stylesheet" href="/assets/css/form.css">
 {% endblock %}
 
 {% block body %}
@@ -51,4 +52,94 @@
 			</div>
 		</div>
 	</article>
+
+	<!-- Comments -->
+	<div class="container px-4 px-lg-5 my-3">
+		<div class="row gx-4 gx-lg-5 justify-content-center">
+			<div class="col-md-10 col-lg-8 col-xl-7">
+				<h2>Commentaires</h2>
+			</div>
+		</div>
+
+		<div class="container px-4 px-lg-5">
+			{% if post.commentsAllowed %}
+				<div class="row gx-4 gx-lg-5 justify-content-center">
+					<div class="col-md-10 col-lg-8 col-xl-7">
+						{% if post.comments|length > 0 %}
+							<ul class="list-group list-group-flush">
+								{% for comment in post.comments %}
+									{% include "front/includes/comment.html.twig" %}
+								{% endfor %}
+							</ul>
+						{% else %}
+							<div class="row gx-4 gx-lg-5 justify-content-center">Aucun commentaire sur ce post.</div>
+						{% endif %}
+
+						{% if user %}
+							{% if user.emailVerified %}
+								<div class="row gx-4 gx-lg-5">
+									<form id="commentForm" action="/posts/{{ post.id }}/createComment#commentForm" method="post">
+										<div class="form-floating">
+											<input type="text" class="form-control" id="title" name="commentForm[title]" placeholder="Entrez votre nom..." value="{{ commentFormResult.values.title }}" maxlength="255" required/>
+											<label for="title">Titre</label>
+											{% if commentFormResult.errors.titleMissing %}
+												<div class="invalid-feedback">Le titre est requis.</div>
+											{% endif %}
+											{% if commentFormResult.errors.titleTooLong %}
+												<div class="invalid-feedback">Le titre ne peut pas dépasser 255 caractères.</div>
+											{% endif %}
+										</div>
+
+										<div class="form-floating">
+											<textarea class="form-control" id="message" name="commentForm[body]" placeholder="Entrez votre commentaire..." style="height: 12rem" maxlength="65535" required>{{ commentFormResult.values.body }}</textarea>
+											<label for="comment">Commentaire</label>
+											{% if commentFormResult.errors.bodyMissing %}
+												<div class="invalid-feedback">Le commentaire ne peut pas être vide.</div>
+											{% endif %}
+											{% if commentFormResult.errors.bodyTooLong %}
+												<div class="invalid-feedback">Le commentaire ne peut pas dépasser 65535 caractères.</div>
+											{% endif %}
+										</div>
+
+										<!-- Submit success message-->
+										{% if commentFormResult.success %}
+											<div id="submitSuccessMessage">
+												<div class="text-center mb-3">
+													<div class="fw-bolder">
+														Le commentaire a été envoyé.<br/>
+														Il est soumis à validation avant publication sur le blog.</div>
+												</div>
+											</div>
+										{% endif %}
+
+										<!-- Submit error message-->
+										{% if commentFormResult.failure %}
+											<div id="submitErrorMessage">
+												<div class="text-center text-danger mb-3">Erreur lors de l'envoi.</div>
+											</div>
+										{% endif %}
+
+										<!-- Submit Button-->
+										<div class="text-center">
+											<button class="btn btn-primary text-uppercase my-2" id="submitButton" type="submit">Envoyer</button>
+										</div>
+									</form>
+								</div>
+							{% else %}
+								<div>Vous devez vérifier votre adresse e-mail pour poster des commentaires.</div>
+							{% endif %}
+						{% else %}
+							<div>Vous devez vous connecter pour poster des commentaires.</div>
+							<div class="text-center">
+								<a class="btn btn-primary text-uppercase my-2" href="/login">Se connecter</a>
+							</div>
+						{% endif %}
+
+					{% else %}
+						<div class="row gx-4 gx-lg-5 justify-content-center">Les commentaires ne sont pas autorisés.</div>
+					</div>
+				</div>
+			{% endif %}
+		</div>
+	</div>
 {% endblock %}


### PR DESCRIPTION
Fixes #7 and #30

## Front

### Add a comment

A form has been added at the bottom of a blog post page to allow authenticated users with a verified email address to add comments.  
The comments are not immediately shown on the page; instead they need to be approved by an admin.

### Delete a comment

A button to allow authenticated users to delete their own comments has been added for each blog post comment.

## Back

A comments validation page has been added to allow admins to approve or reject comments that are not yet published.  
If a comment is rejected, a reject reason is required and the author of the comment receives an email with the reject reason.