### PR TITLE
Add failsafe error handling routine

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -21,9 +21,12 @@ abstract class Controller
     protected HTTPRequest $request;
     protected HTTPResponse $response;
 
-    public function __construct()
+    /**
+     * @param bool $emergency Avoid all risky calls (eg: database) in case of a serious crash.
+     */
+    public function __construct(bool $emergency = false)
     {
-        $this->request = new HTTPRequest();
+        $this->request = new HTTPRequest($emergency);
         $this->response = new HTTPResponse();
 
         $this->loader = new FilesystemLoader(Constants::$TEMPLATES);

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -45,7 +45,7 @@ class ErrorController extends Controller
         $this->response->sendText($this->e->getMessage());
     }
 
-    static public function emergencyShow(\Throwable $e)
+    static public function emergencyShow(\Throwable $e): void
     {
         $serverException = new ServerException(previous: $e);
         (new static($serverException, true))->show();

--- a/src/Core/HTTP/HTTPRequest.php
+++ b/src/Core/HTTP/HTTPRequest.php
@@ -41,7 +41,7 @@ class HTTPRequest
      */
     public readonly ?User $user;
 
-    public function __construct()
+    public function __construct(bool $emergency = false)
     {
         $this->method = $_SERVER["REQUEST_METHOD"];
 
@@ -61,8 +61,7 @@ class HTTPRequest
             : (array) json_decode(file_get_contents("php://input"), true);
 
 
-
-        if (isset($_SESSION["userId"])) {
+        if (isset($_SESSION["userId"]) && !$emergency) {
             $this->user = (new UserService())->getUser($_SESSION["userId"]);
         } else {
             $this->user = null;


### PR DESCRIPTION
I added a catch-all exception handler in case of a serious crash.
Risky calls ((eg: database) are now avoided when a serious crash happens.
This allows to still display a nice error page even when a catastrophic failure happens.