### PR TITLE
Create email body class

### DIFF
--- a/src/Entity/EmailBody.php
+++ b/src/Entity/EmailBody.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Entity;
+
+use App\Service\TwigService;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+
+class EmailBody
+{
+    private Environment $twig;
+
+    public function __construct(
+        private string $template,
+        private string $subject,
+        private array $context,
+    ) {
+        $this->twig = (new TwigService())->getEnvironment();
+    }
+
+    public function getHTML(): string
+    {
+        return $this->twig->render(
+            "email/{$this->template}.html.twig",
+            array_merge(
+                ["subject" => $this->subject],
+                $this->context,
+            )
+        );
+    }
+
+    public function getPlain(): string
+    {
+        try {
+            return $this->twig->render(
+                "email/{$this->template}-plain.txt.twig",
+                $this->context,
+            );
+        } catch (LoaderError $e) {
+            return "";
+        }
+    }
+};

--- a/src/Service/CommentService.php
+++ b/src/Service/CommentService.php
@@ -176,33 +176,29 @@ class CommentService
         $commentTitle = $comment->getTitle();
         $commentBody = $comment->getBody();
 
-        $subject = "Commentaire rejeté";
-
-        $emailBody = <<<HTML
-            Bonjour,
-
-            Votre commentaire a été rejeté pour la raison suivante :
-
-            $reason
-
-            Post : $postTitle
-            
-            Commentaire
-            ===========
-            Titre : $commentTitle
-            Corps :
-            $commentBody
-            HTML;
+        $twig = (new TwigService())->getEnvironment();
 
         $emailService = new EmailService();
+
+        $subject = "Commentaire rejeté";
+
+        $emailBody = $emailService->createEmailBody(
+            "reject-comment",
+            $subject,
+            compact(
+                "reason",
+                "postTitle",
+                "commentTitle",
+                "commentBody",
+            )
+        );
 
         $emailSent = $emailService
             ->addTo($comment->getAuthor()->getEmail())
             ->setSubject($subject)
             ->setBody($emailBody)
-            ->setHTML(false)
             ->send();
 
-        return true;
+        return $emailSent;
     }
 }

--- a/src/Service/ContactFormService.php
+++ b/src/Service/ContactFormService.php
@@ -52,27 +52,23 @@ class ContactFormService
 
         $twig = (new TwigService())->getEnvironment();
 
-        $subject = "Message de {$contactForm["name"]}";
-
-        $emailBody = [
-            "html" => $twig->render(
-                "email/contact-form.html.twig",
-                compact("subject", "contactForm")
-            ),
-            "plain" => $twig->render(
-                "email/contact-form-plain.txt.twig",
-                compact("contactForm")
-            ),
-        ];
-
         $emailService = new EmailService();
 
-        $emailService
+        $subject = "Message de {$contactForm["name"]}";
+
+        $emailBody = $emailService->createEmailBody(
+            "contact-form",
+            $subject,
+            compact("contactForm")
+        );
+
+        $emailSent = $emailService
             ->setFrom($_ENV["MAIL_SENDER_EMAIL"], $_ENV["MAIL_SENDER_NAME"])
             ->addTo($_ENV["CONTACT_FORM_EMAIL"])
             ->setSubject($subject)
-            ->setBody($emailBody["html"], $emailBody["plain"]);
+            ->setBody($emailBody)
+            ->send();
 
-        return $emailService->send();
+        return $emailSent;
     }
 }

--- a/src/Service/EmailService.php
+++ b/src/Service/EmailService.php
@@ -5,6 +5,7 @@ namespace App\Service;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
 use App\Core\ErrorLogger;
+use App\Entity\EmailBody;
 
 class EmailService
 {
@@ -125,8 +126,11 @@ class EmailService
         return $this;
     }
 
-    public function setBody(string $html, string $plain = ""): static
+    public function setBody(EmailBody $body): static
     {
+        $html = $body->getHTML();
+        $plain = $body->getPlain();
+
         $this->htmlBody = $html;
 
         if ($plain) {
@@ -141,5 +145,22 @@ class EmailService
         $this->isHTML = $isHTML;
 
         return $this;
+    }
+
+    /**
+     * Create an email body from a Twig template.
+     * 
+     * @param string $template Filename of the template, without the extension.  
+     *                         eg: "reject-comment", without "html.twig" or "plain.txt.twig".
+     * @param string $subject  E-mail subject.
+     * @param array $context   Associative array to pass to the Twig template renderer.  
+     *                         Those variables can be used in the template.
+     */
+    public function createEmailBody(
+        string $template,
+        string $subject,
+        array $context,
+    ): EmailBody {
+        return new EmailBody($template, $subject, $context);
     }
 }

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -242,28 +242,24 @@ class UserService
 
         $twig = (new TwigService())->getEnvironment();
 
-        $subject = "Vérification de votre adresse e-mail";
-
-        $emailBody = [
-            "html" => $twig->render(
-                "email/email-verification.html.twig",
-                compact("subject", "emailVerificationToken")
-            ),
-            "plain" => $twig->render(
-                "email/email-verification-plain.txt.twig",
-                compact("emailVerificationToken")
-            ),
-        ];
-
         $emailService = new EmailService();
 
-        $emailService
+        $subject = "Vérification de votre adresse e-mail";
+
+        $emailBody = $emailService->createEmailBody(
+            "email-verification",
+            $subject,
+            compact("emailVerificationToken")
+        );
+
+        $emailSent = $emailService
             ->setFrom($_ENV["MAIL_SENDER_EMAIL"], $_ENV["MAIL_SENDER_NAME"])
             ->addTo($email)
             ->setSubject($subject)
-            ->setBody($emailBody["html"], $emailBody["plain"]);
+            ->setBody($emailBody)
+            ->send();
 
-        return $emailService->send();
+        return $emailSent;
     }
 
     /**
@@ -329,28 +325,24 @@ class UserService
 
         $twig = (new TwigService())->getEnvironment();
 
-        $subject = "Réinitialisation de mot de passe";
-
-        $emailBody = [
-            "html" => $twig->render(
-                "email/password-reset.html.twig",
-                compact("subject", "passwordResetToken")
-            ),
-            "plain" => $twig->render(
-                "email/password-reset-plain.txt.twig",
-                compact("passwordResetToken")
-            ),
-        ];
-
         $emailService = new EmailService();
 
-        $emailService
+        $subject = "Réinitialisation de mot de passe";
+
+        $emailBody = $emailService->createEmailBody(
+            "password-reset",
+            $subject,
+            compact("passwordResetToken")
+        );
+
+        $emailSent = $emailService
             ->setFrom($_ENV["MAIL_SENDER_EMAIL"], $_ENV["MAIL_SENDER_NAME"])
             ->addTo($email)
             ->setSubject($subject)
-            ->setBody($emailBody["html"], $emailBody["plain"]);
+            ->setBody($emailBody)
+            ->send();
 
-        return $emailService->send();
+        return $emailSent;
     }
 
     public function verifyPasswordResetToken(string $token): bool

--- a/templates/email/reject-comment-plain.txt.twig
+++ b/templates/email/reject-comment-plain.txt.twig
@@ -1,0 +1,13 @@
+Bonjour,
+
+Votre commentaire a été rejeté pour la raison suivante :
+
+{{ reason }}
+
+Post : {{ postTitle }}
+            
+Commentaire
+===========
+Titre : {{ commentTitle }}
+Corps :
+{{ commentBody }}

--- a/templates/email/reject-comment.html.twig
+++ b/templates/email/reject-comment.html.twig
@@ -1,0 +1,19 @@
+{% extends "email/layout.html.twig" %}
+
+{% block body %}
+	<p>Bonjour,</p>
+
+	<p>Votre commentaire a été rejeté pour la raison suivante :</p>
+
+	<p>{{ reason }}</p>
+
+	<p>Post :
+		{{ postTitle }}</p>
+
+	<p>Commentaire</p>
+
+	<p>Titre :
+		{{ commentTitle }}</p>
+	<p>Corps :</p>
+	<p>{{ commentBody }}</p>
+{% endblock %}


### PR DESCRIPTION
Create EmailBody entity to harmonize and centralize email creation.  
All email bodies must now be generated by a Twig template located in the "templates/email" directory.

Also added a new template for comment rejection emails.