### PR TITLE
Add Quill editor to create/edit posts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "phpmailer/phpmailer": "^6.9",
     "twig/markdown-extra": "^3.8",
     "league/commonmark": "^2.4",
-    "hidehalo/nanoid-php": "^1.1"
+    "hidehalo/nanoid-php": "^1.1",
+    "nadar/quill-delta-parser": "^3.4"
   },
   "require-dev": {
     "symfony/var-dumper": "^7.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19b3feb266d9d2ae81bbd8aeee2c2b74",
+    "content-hash": "d63e805f38b1bcdd59410f09caaadaa7",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -387,6 +387,69 @@
                 }
             ],
             "time": "2022-12-11T20:36:23+00:00"
+        },
+        {
+            "name": "nadar/quill-delta-parser",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nadar/quill-delta-parser.git",
+                "reference": "6881d5b0607836a961b756ee262f5b6c43852e0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nadar/quill-delta-parser/zipball/6881d5b0607836a961b756ee262f5b6c43852e0c",
+                "reference": "6881d5b0607836a961b756ee262f5b6c43852e0c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^8.0",
+                "rector/rector": "^0.14.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "nadar\\quill\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Basil Suter",
+                    "email": "git@nadar.io"
+                }
+            ],
+            "description": "A PHP library to parse Quill WYSIWYG editor deltas into HTML - flexible and extendible for custom elements.",
+            "keywords": [
+                "delta",
+                "html",
+                "parser",
+                "quill",
+                "quill-delta",
+                "quill-editor",
+                "quilljs",
+                "renderer"
+            ],
+            "support": {
+                "issues": "https://github.com/nadar/quill-delta-parser/issues",
+                "source": "https://github.com/nadar/quill-delta-parser/tree/3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/nadar",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-09-14T13:12:25+00:00"
         },
         {
             "name": "nette/schema",

--- a/public/js/admin/post-edit.js
+++ b/public/js/admin/post-edit.js
@@ -1,0 +1,46 @@
+// Hide the textarea element
+/** @type {HTMLTextAreaElement} */
+const bodyTextarea = document.getElementById("body");
+if (bodyTextarea) {
+  bodyTextarea.setAttribute("hidden", true);
+}
+
+const quillEditor = new Quill("#quill-editor", {
+  modules: {
+    toolbar: [
+      ["bold", "italic", "underline", "strike"], // toggled buttons
+      ["blockquote", "code-block"],
+
+      [{ list: "ordered" }, { list: "bullet" }],
+      [{ script: "sub" }, { script: "super" }], // superscript/subscript
+      [{ indent: "-1" }, { indent: "+1" }], // outdent/indent
+      [{ direction: "rtl" }], // text direction
+
+      [{ size: ["small", false, "large", "huge"] }], // custom dropdown
+      [{ header: [1, 2, 3, 4, 5, 6, false] }],
+
+      [{ color: [] }, { background: [] }], // dropdown with defaults from theme
+      [{ font: [] }],
+      [{ align: [] }],
+
+      ["clean"], // remove formatting button
+    ],
+  },
+  placeholder: "Corps du post...",
+  theme: "snow",
+});
+
+try {
+  quillEditor.setContents(JSON.parse(bodyTextarea.textContent));
+} catch (error) {
+  quillEditor.setText(bodyTextarea.textContent);
+}
+
+/** @type {HTMLFormElement} */
+const postForm = document.getElementById("postForm");
+
+if (postForm) {
+  postForm.addEventListener("submit", (e) => {
+    bodyTextarea.textContent = JSON.stringify(quillEditor.getContents());
+  });
+}

--- a/src/Service/TwigService.php
+++ b/src/Service/TwigService.php
@@ -2,6 +2,9 @@
 
 namespace App\Service;
 
+use App\Core\Constants;
+use App\Core\Security;
+use App\Core\HTTP\HTTPRequest;
 use Twig\Loader\FilesystemLoader;
 use Twig\Environment;
 use Twig\RuntimeLoader\RuntimeLoaderInterface;
@@ -9,9 +12,8 @@ use Twig\Extra\Intl\IntlExtension;
 use Twig\Extra\Markdown\DefaultMarkdown;
 use Twig\Extra\Markdown\MarkdownRuntime;
 use Twig\Extra\Markdown\MarkdownExtension;
-use App\Core\HTTP\HTTPRequest;
-use App\Core\Constants;
-use App\Core\Security;
+use nadar\quill\Lexer;
+use Twig\TwigFilter;
 
 class TwigService
 {
@@ -42,6 +44,13 @@ class TwigService
                     }
                 }
             }
+        );
+
+        $this->environment->addFilter(
+            new TwigFilter(
+                "quill",
+                fn (string $delta) => (new Lexer($delta))->render()
+            )
         );
     }
 

--- a/templates/admin/post-edit.html.twig
+++ b/templates/admin/post-edit.html.twig
@@ -2,6 +2,12 @@
 
 {% block stylesheets %}
 	<link rel="stylesheet" href="/assets/css/form.css">
+	<link href="//cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+{% endblock %}
+
+{% block javascript %}
+	<script defer src="//cdn.quilljs.com/1.3.6/quill.min.js"></script>
+	<script defer src="/assets/js/admin/post-edit.js"></script>
 {% endblock %}
 
 {% set breadcrumbs = [
@@ -79,8 +85,9 @@
 
 						<div class="input-group input-group-static mt-4">
 							<label for="body">Corps du post</label>
-							<textarea class="form-control" id="body" name="post[body]" placeholder="Entrez le corps du post" style="height: 30rem" required>{{ post.body }}</textarea>
+							<textarea class="form-control" id="body" name="post[body]" placeholder="Entrez le corps du post" style="height: 30rem" hidden required>{{ post.body }}</textarea>
 						</div>
+						<div id="quill-editor"></div>
 
 						<div class="input-group input-group-static mt-4">
 							<label for="category">Catégorie</label>

--- a/templates/front/post-single.html.twig
+++ b/templates/front/post-single.html.twig
@@ -56,7 +56,7 @@
 		<div class="container px-4 px-lg-5">
 			<div class="row gx-4 gx-lg-5 justify-content-center">
 				<div class="col-md-10 col-lg-8 col-xl-7">
-					{{ post.body|markdown_to_html }}
+					{{ post.body|quill|raw }}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Fixes #22 

Added a Quill editor (quilljs) to the post edit page.

Created a Twig filter to render Quill content.

Updated the post-single template to display the Quill-formatted post content.