### PR TITLE
Fix blog post creation form

### DIFF
--- a/templates/admin/post-edit.html.twig
+++ b/templates/admin/post-edit.html.twig
@@ -85,7 +85,7 @@
 
 						<div class="input-group input-group-static mt-4">
 							<label for="body">Corps du post</label>
-							<textarea class="form-control" id="body" name="post[body]" placeholder="Entrez le corps du post" style="height: 30rem" hidden required>{{ post.body }}</textarea>
+							<textarea class="form-control" id="body" name="post[body]" placeholder="Entrez le corps du post" style="height: 30rem" hidden>{{ post.body }}</textarea>
 						</div>
 						<div id="quill-editor"></div>
 

--- a/templates/front/post-single.html.twig
+++ b/templates/front/post-single.html.twig
@@ -165,7 +165,7 @@
 						{% endif %}
 
 					{% else %}
-						<div class="row gx-4 gx-lg-5 justify-content-center">Les commentaires ne sont pas autorisés.</div>
+						<div class="row gx-4 gx-lg-5 justify-content-center">Les commentaires ne sont pas autorisés sur ce post.</div>
 					</div>
 				</div>
 			{% endif %}


### PR DESCRIPTION
Fixed an issue where a blog post could not be created due to the textarea field being hidden.

Updated to "no comments allowed" message.