### PR TITLE
Fix author name in comments review

### DIFF
--- a/src/Repository/CommentRepository.php
+++ b/src/Repository/CommentRepository.php
@@ -224,7 +224,7 @@ class CommentRepository extends Repository
                 c.createdAt
             FROM comments c
             LEFT JOIN posts p ON p.id = c.postId
-            LEFT JOIN users u ON u.id = p.author
+            LEFT JOIN users u ON u.id = c.author
             WHERE approved = 0
             ORDER BY c.createdAt ASC"
         );

--- a/templates/admin/comment-review.html.twig
+++ b/templates/admin/comment-review.html.twig
@@ -35,6 +35,11 @@
 				<div class="col-md-10 col-lg-8 col-xl-7 mb-5">
 
 					<div class="mb-3">
+						<div class="fw-bold">Auteur</div>
+						<span>{{ comment.author }}</span>
+					</div>
+
+					<div class="mb-3">
 						<div class="fw-bold">Post</div>
 						<span>{{ post.title }}</span>
 						(<a href="/posts/{{ post.id }}" target="_blank">voir le post</a>)


### PR DESCRIPTION
Fixes #64 

I corrected the SQL statement to fetch the correct user info for the comment's author.

I also added the author's name in the comment review page.
